### PR TITLE
Sync terrateam-prebuilt.yml with gold-standard workflow

### DIFF
--- a/github/actions/workflows/default/terrateam-prebuilt.yml
+++ b/github/actions/workflows/default/terrateam-prebuilt.yml
@@ -1,7 +1,17 @@
+##########################################################################
+# DO NOT MODIFY
+#
+# THIS FILE SHOULD LIVE IN .github/workflows/terrateam.yml
+#
+# Looking for the Terrateam configuration file? .terrateam/config.yml.
+#
+# See https://terrateam.io/docs
+##########################################################################
 name: 'Terrateam Workflow'
 on:
   workflow_dispatch:
     inputs:
+      # The work-token and api-base-url are automatically passed in by the Terrateam backend
       work-token:
         description: 'Work Token'
         required: true
@@ -13,8 +23,7 @@ on:
       runs_on:
         description: 'runs-on configuration'
         type: string
-        default: ubuntu-latest
-
+        default: '"ubuntu-latest"'
 jobs:
   terrateam:
     permissions:
@@ -27,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Terrateam Action
+        id: terrateam
         uses: docker://ghcr.io/terrateamio/action:v1
         with:
           args: >


### PR DESCRIPTION
## Summary
- Align `terrateam-prebuilt.yml` with `terrateam.yml` (the gold-standard) while preserving its `docker://ghcr.io/terrateamio/action:v1` step
- Add the DO NOT MODIFY header and the comment noting work-token/api-base-url are passed by the backend
- Fix `runs_on` default from `ubuntu-latest` to `'"ubuntu-latest"'` so it parses correctly under `fromJSON`
- Add `id: terrateam` to the action step

## Test plan
- [ ] Trigger the prebuilt workflow via workflow_dispatch and confirm the default `runs_on` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)